### PR TITLE
Fixed codechecker problems and added two new settings for EnlighterJS

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -33,7 +33,7 @@
  *               Done here as core Gruntfile.js currently *nix only.
  *
  * @package filter_synhi.
- * @copyright  &copy; 2020-onwards G J Barnard.
+ * @copyright  © 2020-onwards G J Barnard.
  * @author G J Barnard - {@link http://moodle.org/user/profile.php?id=442195}
  * @author Based on code originally written by Andrew Nicols, Joby Harding, Bas Brands, David Scotson and many other contributors.
  * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later

--- a/Readme.md
+++ b/Readme.md
@@ -3,7 +3,7 @@ Introduction
 SynHi Filter.
 
 A syntax highlighter filter for Moodle with the choice of either EnlighterJS or SyntaxHighlighter
-as the 'engine'.  The administrator has 'preview' settings to see what the look will be on example
+as the 'engine'. The administrator has 'preview' settings to see what the look will be on example
 code before the saving.
 
 When active, content with a 'pre' or 'code' tag within a course, module or block will be highlighted.
@@ -11,6 +11,7 @@ Specifically between the Course and Block contexts - https://docs.moodle.org/39/
 
 Features
 ========
+
 * Syntax Highlighting.
 
 Screenshots
@@ -24,9 +25,9 @@ Screenshots
 
 About
 =====
-Copyright  &copy; 2020-onwards G J Barnard.
-Author     G J Barnard - http://about.me/gjbarnard and http://moodle.org/user/profile.php?id=442195
-License    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later.  For Moodle plugin code only.
+Copyright © 2020-onwards G J Barnard.
+Author G J Barnard - http://about.me/gjbarnard and http://moodle.org/user/profile.php?id=442195
+License    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later. For Moodle plugin code only.
 
 Developed and maintained by
 ===========================
@@ -36,13 +37,13 @@ Web profile | http://about.me/gjbarnard
 
 Free Software
 =============
-The SynHi filter is 'free' software under the terms of the GNU GPLv3 License, please see 'LICENSE'.  It
+The SynHi filter is 'free' software under the terms of the GNU GPLv3 License, please see 'LICENSE'. It
 contains third party 'highlighers' which are licensed differenty, see 'Highlighters'.
 
 It can be obtained for free from:
 https://github.com/gjb2048/moodle-filter_synhi/releases
 
-You have all the rights granted to you by the GPLv3 license.  If you are unsure about anything, then the
+You have all the rights granted to you by the GPLv3 license. If you are unsure about anything, then the
 FAQ - www.gnu.org/licenses/gpl-faq.html - is a good place to look.
 
 If you reuse any of the code then I kindly ask that you make reference to the filter.
@@ -58,16 +59,18 @@ SyntaxHighlighter - https://github.com/syntaxhighlighter/syntaxhighlighter - MIT
 
 Support
 =======
-As SynHi is licensed under the GNU GPLv3 License it comes with NO support.  If you would like support from
-me then I'm happy to provide it for a fee (please see my contact details above).  Otherwise, the 'General plugins'
+As SynHi is licensed under the GNU GPLv3 License it comes with NO support. If you would like support from
+me then I'm happy to provide it for a fee (please see my contact details above). Otherwise, the 'General plugins'
 forum: moodle.org/mod/forum/view.php?id=44 is an excellent place to ask questions.
 
 Sponsorships
 ============
-This filter is provided to you for free, and if you want to express your gratitude for using this filter, please consider sponsoring
+This filter is provided to you for free, and if you want to express your gratitude for using this filter, please
+consider sponsoring
 by:
 
-PayPal - Please contact me via my 'Moodle profile' (above) for details as I am an individual and therefore am unable to have
+PayPal - Please contact me via my 'Moodle profile' (above) for details as I am an individual and therefore am unable to
+have
 'buy me now' buttons under their terms.
 
 Sponsorships may allow me to provide you with more or better features in less time.
@@ -75,11 +78,12 @@ Sponsorships may allow me to provide you with more or better features in less ti
 Required version of Moodle
 ==========================
 This version works with:
- - Moodle 3.7 version 2019052000.00 (Build: 20190520) and above within the 3.7 branch.
- - Moodle 3.8 version 2019111800.00 (Build: 20191118) and above within the 3.8 branch.
- - Moodle 3.9 version 2020061500.00 (Build: 20200615) and above within the 3.9 branch.
- - Moodle 3.10 version 2020110900.00 (Build: 20201109) and above within the 3.10 branch.
- - Moodle 3.11 version 2021051700.00 (Build: 20210517) and above within the 3.11 branch.
+
+- Moodle 3.7 version 2019052000.00 (Build: 20190520) and above within the 3.7 branch.
+- Moodle 3.8 version 2019111800.00 (Build: 20191118) and above within the 3.8 branch.
+- Moodle 3.9 version 2020061500.00 (Build: 20200615) and above within the 3.9 branch.
+- Moodle 3.10 version 2020110900.00 (Build: 20201109) and above within the 3.10 branch.
+- Moodle 3.11 version 2021051700.00 (Build: 20210517) and above within the 3.11 branch.
 
 Please ensure that your hardware and software complies with 'Requirements' in 'Installing Moodle' on
 'docs.moodle.org/37/en/Installing_Moodle', 'docs.moodle.org/38/en/Installing_Moodle',
@@ -88,43 +92,52 @@ or 'docs.moodle.org/311/en/Installing_Moodle' respectively.
 
 Installation
 ============
- 1. Ensure you have the version of Moodle as stated above in 'Required version of Moodle'.  This is essential as the
-    filter relies on underlying core code that is out of my control.
- 2. Login as an administrator and put Moodle in 'Maintenance Mode' so that there are no users using it bar you as the administrator.
- 3. Copy the extracted 'synhi' folder to the '/filter/' folder.
- 4. Go to 'Site administration' -> 'Notifications' and follow standard the 'plugin' update notification.
- 5. Put Moodle out of Maintenance Mode.
+
+1. Ensure you have the version of Moodle as stated above in 'Required version of Moodle'. This is essential as the
+   filter relies on underlying core code that is out of my control.
+2. Login as an administrator and put Moodle in 'Maintenance Mode' so that there are no users using it bar you as the
+   administrator.
+3. Copy the extracted 'synhi' folder to the '/filter/' folder.
+4. Go to 'Site administration' -> 'Notifications' and follow standard the 'plugin' update notification.
+5. Put Moodle out of Maintenance Mode.
 
 Upgrading
 =========
- 1. Ensure you have the version of Moodle as stated above in 'Required version of Moodle'.  This is essential as the
-    filter relies on underlying core code that is out of my control.
- 2. Login as an administrator and put Moodle in 'Maintenance Mode' so that there are no users using it bar you as the administrator.
- 3. Make a backup of your old 'synhi' folder in '/filter/' and then delete the folder.
- 4. Copy the replacement extracted 'synhi' folder to the '/filter/' folder.
- 5. Go to 'Site administration' -> 'Notifications' and follow standard the 'plugin' update notification.
- 6. If automatic 'Purge all caches' appears not to work by lack of display etc. then perform a manual 'Purge all caches'
+
+1. Ensure you have the version of Moodle as stated above in 'Required version of Moodle'. This is essential as the
+   filter relies on underlying core code that is out of my control.
+2. Login as an administrator and put Moodle in 'Maintenance Mode' so that there are no users using it bar you as the
+   administrator.
+3. Make a backup of your old 'synhi' folder in '/filter/' and then delete the folder.
+4. Copy the replacement extracted 'synhi' folder to the '/filter/' folder.
+5. Go to 'Site administration' -> 'Notifications' and follow standard the 'plugin' update notification.
+6. If automatic 'Purge all caches' appears not to work by lack of display etc. then perform a manual 'Purge all caches'
    under 'Home -> Site administration -> Development -> Purge all caches'.
- 7. Put Moodle out of Maintenance Mode.
+7. Put Moodle out of Maintenance Mode.
 
 Uninstallation
 ==============
- 1. Put Moodle in 'Maintenance Mode' so that there are no users using it bar you as the administrator.
- 2. Go to Site administration -> Plugins -> Filters -> Manage filters.
- 3. Click on 'Uninstall' and follow the on screen instructions.
- 4. Put Moodle out of Maintenance Mode.
+
+1. Put Moodle in 'Maintenance Mode' so that there are no users using it bar you as the administrator.
+2. Go to Site administration -> Plugins -> Filters -> Manage filters.
+3. Click on 'Uninstall' and follow the on screen instructions.
+4. Put Moodle out of Maintenance Mode.
 
 Reporting Issues
 ================
-Before reporting an issue, please ensure that you are running the current version for your release of Moodle.  It is essential
+Before reporting an issue, please ensure that you are running the current version for your release of Moodle. It is
+essential
 that you are operating the required version of Moodle as stated at the top - this is because the theme relies on core
 functionality that is out of its control.
 
-I operate a policy that I will fix all genuine issues for free.  Improvements are at my discretion.  I am happy to make bespoke
+I operate a policy that I will fix all genuine issues for free. Improvements are at my discretion. I am happy to make
+bespoke
 customisations / improvements for a negotiated fee.
 
-It is essential that you provide as much information as possible, the critical information being the contents of the theme's
-version.php file.  Other version information such as specific Moodle version, theme name and version also helps.  A screen shot
+It is essential that you provide as much information as possible, the critical information being the contents of the
+theme's
+version.php file. Other version information such as specific Moodle version, theme name and version also helps. A screen
+shot
 can be really useful in visualising the issue along with any files you consider to be relevant.
 
 Report issues on: https://github.com/gjb2048/moodle-filter_synhi/issues
@@ -136,7 +149,8 @@ See Changes.md
 Refs
 ====
 
-iframe resize: https://stackoverflow.com/questions/9975810/make-iframe-automatically-adjust-height-according-to-the-contents-without-using
+iframe
+resize: https://stackoverflow.com/questions/9975810/make-iframe-automatically-adjust-height-according-to-the-contents-without-using
 
 Me
 ==

--- a/amd/src/synhi.js
+++ b/amd/src/synhi.js
@@ -17,7 +17,7 @@
  * SynHi filter.
  *
  * @package    filter_synhi
- * @copyright  &copy; 2020-onwards G J Barnard.
+ * @copyright  © 2020-onwards G J Barnard.
  * @author     G J Barnard - {@link http://moodle.org/user/profile.php?id=442195}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later.
  */

--- a/classes/admin_setting_highlight.php
+++ b/classes/admin_setting_highlight.php
@@ -83,7 +83,7 @@ class admin_setting_highlight extends \admin_setting {
      * @param string $query
      * @return string Returns an HTML string
      */
-    public function output_html($data, $query='') {
+    public function output_html($data, $query = '') {
         global $OUTPUT;
 
         $context = new \stdClass();

--- a/classes/admin_setting_highlight.php
+++ b/classes/admin_setting_highlight.php
@@ -18,22 +18,26 @@
  * SynHi filter.
  *
  * @package    filter_synhi
- * @copyright  &copy; 2020-onwards G J Barnard.
+ * @copyright  © 2020-onwards G J Barnard.
  * @author     G J Barnard - {@link http://moodle.org/user/profile.php?id=442195}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later.
  */
 
 namespace filter_synhi;
 
+use admin_setting;
+use dml_exception;
+use stdClass;
+
 /**
  * SynHi admin_setting_highlight based on admin_setting_description by Amaia Anabitarte.
  *
  * @package    filter_synhi
- * @copyright  &copy; 2020-onwards G J Barnard.
+ * @copyright  © 2020-onwards G J Barnard.
  * @author     G J Barnard - {@link http://moodle.org/user/profile.php?id=442195}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later.
  */
-class admin_setting_highlight extends \admin_setting {
+class admin_setting_highlight extends admin_setting {
 
     /**
      * Not a setting, just text
@@ -52,7 +56,7 @@ class admin_setting_highlight extends \admin_setting {
      *
      * @return bool Always returns true
      */
-    public function get_setting() {
+    public function get_setting(): bool {
         return true;
     }
 
@@ -61,7 +65,7 @@ class admin_setting_highlight extends \admin_setting {
      *
      * @return bool Always returns true
      */
-    public function get_defaultsetting() {
+    public function get_defaultsetting(): bool {
         return true;
     }
 
@@ -71,7 +75,7 @@ class admin_setting_highlight extends \admin_setting {
      * @param mixed $data Gets converted to str for comparison against yes value
      * @return string Always returns an empty string
      */
-    public function write_setting($data) {
+    public function write_setting($data): string {
         // Do not write any setting.
         return '';
     }
@@ -82,21 +86,21 @@ class admin_setting_highlight extends \admin_setting {
      * @param string $data
      * @param string $query
      * @return string Returns an HTML string
+     * @throws dml_exception
      */
-    public function output_html($data, $query = '') {
+    public function output_html($data, $query = ''): string {
         global $OUTPUT;
 
-        $context = new \stdClass();
+        $context = new stdClass();
         $context->title = $this->visiblename;
         $context->description = $this->description;
 
-        $toolbox = \filter_synhi\toolbox::get_instance();
+        $toolbox = toolbox::get_instance();
         $highlightcontext = $toolbox->setting_highlight();
         if (!empty($highlightcontext)) {
             $context->highlightdata = $highlightcontext['highlightdata'];
             $context->code = $highlightcontext['code'];
         }
-
         return $OUTPUT->render_from_template('filter_synhi/setting_highlight', $context);
     }
 }

--- a/classes/output/external.php
+++ b/classes/output/external.php
@@ -39,7 +39,7 @@ class external extends \core\output\external {
      * Return generated markup.
      *
      * @param string $engine Highlighter engine.
-     * @param string $style Highlighter style.
+     * @param string $style  Highlighter style.
      *
      * @return string the markup.
      */
@@ -47,16 +47,16 @@ class external extends \core\output\external {
         // Parameter validation.
         self::validate_parameters(
             self::setting_highlight_example_parameters(),
-            array(
+            [
                 'engine' => $engine,
                 'style' => $style
-            )
+            ]
         );
 
         $toolbox = \filter_synhi\toolbox::get_instance();
         $markup = $toolbox->setting_highlight_example($engine, $style);
 
-        $result = array('markup' => $markup);
+        $result = ['markup' => $markup];
 
         return $result;
     }
@@ -68,11 +68,11 @@ class external extends \core\output\external {
      */
     public static function setting_highlight_example_parameters() {
         return new \external_function_parameters(
-                array(
-                    'engine' => new \external_value(PARAM_TEXT, 'Engine', VALUE_REQUIRED, null, NULL_NOT_ALLOWED),
-                    'style' => new \external_value(PARAM_TEXT, 'Style', VALUE_REQUIRED, null, NULL_NOT_ALLOWED),
-                )
-         );
+            [
+                'engine' => new \external_value(PARAM_TEXT, 'Engine', VALUE_REQUIRED, null, NULL_NOT_ALLOWED),
+                'style' => new \external_value(PARAM_TEXT, 'Style', VALUE_REQUIRED, null, NULL_NOT_ALLOWED),
+            ]
+        );
     }
 
     /**
@@ -82,8 +82,8 @@ class external extends \core\output\external {
      */
     public static function setting_highlight_example_returns() {
         return new \external_single_structure(
-                array(
-                    'markup' => new \external_value(PARAM_RAW, 'Markup'),
-                ), 'Mustache template');
+            [
+                'markup' => new \external_value(PARAM_RAW, 'Markup'),
+            ], 'Mustache template');
     }
 }

--- a/classes/output/external.php
+++ b/classes/output/external.php
@@ -18,18 +18,25 @@
  * SynHi filter.
  *
  * @package    filter_synhi
- * @copyright  &copy; 2020-onwards G J Barnard.
+ * @copyright  © 2020-onwards G J Barnard.
  * @author     G J Barnard - {@link http://moodle.org/user/profile.php?id=442195}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later.
  */
 
 namespace filter_synhi\output;
 
+use dml_exception;
+use external_function_parameters;
+use external_single_structure;
+use external_value;
+use filter_synhi\toolbox;
+use invalid_parameter_exception;
+
 /**
  * SynHi filter.
  *
  * @package    filter_synhi
- * @copyright  &copy; 2020-onwards G J Barnard.
+ * @copyright  © 2020-onwards G J Barnard.
  * @author     G J Barnard - {@link http://moodle.org/user/profile.php?id=442195}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later.
  */
@@ -41,9 +48,11 @@ class external extends \core\output\external {
      * @param string $engine Highlighter engine.
      * @param string $style  Highlighter style.
      *
-     * @return string the markup.
+     * @return array the markup.
+     * @throws dml_exception
+     * @throws invalid_parameter_exception
      */
-    public static function setting_highlight_example($engine, $style) {
+    public static function setting_highlight_example(string $engine, string $style): array {
         // Parameter validation.
         self::validate_parameters(
             self::setting_highlight_example_parameters(),
@@ -53,12 +62,10 @@ class external extends \core\output\external {
             ]
         );
 
-        $toolbox = \filter_synhi\toolbox::get_instance();
+        $toolbox = toolbox::get_instance();
         $markup = $toolbox->setting_highlight_example($engine, $style);
 
-        $result = ['markup' => $markup];
-
-        return $result;
+        return ['markup' => $markup];
     }
 
     /**
@@ -66,11 +73,11 @@ class external extends \core\output\external {
      *
      * @return external_function_parameters
      */
-    public static function setting_highlight_example_parameters() {
-        return new \external_function_parameters(
+    public static function setting_highlight_example_parameters(): external_function_parameters {
+        return new external_function_parameters(
             [
-                'engine' => new \external_value(PARAM_TEXT, 'Engine', VALUE_REQUIRED, null, NULL_NOT_ALLOWED),
-                'style' => new \external_value(PARAM_TEXT, 'Style', VALUE_REQUIRED, null, NULL_NOT_ALLOWED),
+                'engine' => new external_value(PARAM_TEXT, 'Engine', VALUE_REQUIRED, null, NULL_NOT_ALLOWED),
+                'style' => new external_value(PARAM_TEXT, 'Style', VALUE_REQUIRED, null, NULL_NOT_ALLOWED),
             ]
         );
     }
@@ -78,12 +85,12 @@ class external extends \core\output\external {
     /**
      * Returns description of method result value.
      *
-     * @return external_description
+     * @return external_single_structure
      */
-    public static function setting_highlight_example_returns() {
-        return new \external_single_structure(
+    public static function setting_highlight_example_returns(): external_single_structure {
+        return new external_single_structure(
             [
-                'markup' => new \external_value(PARAM_RAW, 'Markup'),
+                'markup' => new external_value(PARAM_RAW, 'Markup'),
             ], 'Mustache template');
     }
 }

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -39,7 +39,7 @@ class provider implements \core_privacy\local\metadata\null_provider {
      *
      * @return  string
      */
-    public static function get_reason() : string {
+    public static function get_reason(): string {
         return 'privacy:nop';
     }
 }

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -18,20 +18,22 @@
  * SynHi filter.
  *
  * @package    filter_synhi
- * @copyright  &copy; 2020-onwards G J Barnard.
+ * @copyright  © 2020-onwards G J Barnard.
  * @author     G J Barnard - {@link http://moodle.org/user/profile.php?id=442195}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later.
  */
 
 namespace filter_synhi\privacy;
 
+use core_privacy\local\metadata\null_provider;
+
 /**
  * The SynHi filter does not store any user data.
  *
- * @copyright  &copy; 2020-onwards G J Barnard.
+ * @copyright  © 2020-onwards G J Barnard.
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later.
  */
-class provider implements \core_privacy\local\metadata\null_provider {
+class provider implements null_provider {
 
     /**
      * Get the language string identifier with the component's language

--- a/classes/toolbox.php
+++ b/classes/toolbox.php
@@ -25,7 +25,7 @@
 
 namespace filter_synhi;
 
-use \moodle_url;
+use moodle_url;
 
 /**
  * SynHi filter.
@@ -74,7 +74,7 @@ class toolbox {
     /**
      * @var string Enlighter JS styles.
      */
-    public const ENLIGHTERJSSTYLES = array(
+    public const ENLIGHTERJSSTYLES = [
         'atomic' => 'Atomic',
         'beyond' => 'Beyond',
         'bootstrap4' => 'Bootstrap 4',
@@ -88,12 +88,12 @@ class toolbox {
         'monokai' => 'Monokai',
         'mowtwo' => 'Mow Two',
         'rowhammer' => 'Row Hammer'
-    );
+    ];
 
     /**
      * @var string Syntax Highlighter styles.
      */
-    public const SYNTAXHIGHLIGHTERSTYLES = array(
+    public const SYNTAXHIGHLIGHTERSTYLES = [
         'default' => 'Default',
         'django' => 'Django',
         'eclipse' => 'Eclipse',
@@ -103,7 +103,7 @@ class toolbox {
         'midnight' => 'Midnight',
         'rdark' => 'R Dark',
         'swift' => 'Swift'
-    );
+    ];
 
 
     /**
@@ -146,16 +146,17 @@ class toolbox {
 
     /**
      * Highlights the page using the current values.
+     *
      * @param array $config Highlighter config.
      */
     public function highlight_page($config) {
         if (!empty($config->engine)) {
             global $PAGE;
 
-            $enginemethod = $config->engine.'_init';
+            $enginemethod = $config->engine . '_init';
             $init = $this->$enginemethod($config);
 
-            $data = array('data' => array());
+            $data = ['data' => []];
             $data['data']['thecss'] = $init['thecss']->out();
             $data['data']['thejs'] = $init['thejs']->out();
             if (!empty($init['theinit'])) {
@@ -171,11 +172,11 @@ class toolbox {
      * @return array The data.
      */
     public function setting_highlight() {
-        $data = array();
+        $data = [];
 
         $config = get_config('filter_synhi');
         if (!empty($config->engine)) {
-            $enginemethod = $config->engine.'_init';
+            $enginemethod = $config->engine . '_init';
 
             $data['highlightdata'] = $this->$enginemethod($config);
             $data['code'] = htmlentities($config->codeexample);
@@ -188,7 +189,7 @@ class toolbox {
      * Renders the example code in an template that has an iframe with given highlighter engine and style.
      *
      * @param string $engine Highlighter engine.
-     * @param string $style Highlighter style.
+     * @param string $style  Highlighter style.
      *
      * @return string The markup.
      */
@@ -205,7 +206,7 @@ class toolbox {
         if ($proceed) {
             global $OUTPUT, $PAGE;
 
-            $enginemethod = $engine.'_init';
+            $enginemethod = $engine . '_init';
             $config = new \stdClass;
             $config->enlighterjsstyle = $style;
             $config->syntaxhighlighterstyle = $style;
@@ -218,7 +219,7 @@ class toolbox {
             $markup = $OUTPUT->render_from_template('filter_synhi/setting_highlight_example', $context);
         } else {
             $markup = '<p id="setting_highlight_example_frame">';
-            $markup .= 'Invalid parameters passed to \'setting_highlight_example(\''.$engine.'\', \''.$style.'\')\'</p>';
+            $markup .= 'Invalid parameters passed to \'setting_highlight_example(\'' . $engine . '\', \'' . $style . '\')\'</p>';
         }
 
         return $markup;
@@ -233,13 +234,13 @@ class toolbox {
      */
     private function enlighterjs_init($config) {
         $js = new moodle_url(self::ENLIGHTERJSJS);
-        $css = new moodle_url(self::ENLIGHTERJSCSSPRE.$config->enlighterjsstyle.self::ENLIGHTERJSCSSPOST);
+        $css = new moodle_url(self::ENLIGHTERJSCSSPRE . $config->enlighterjsstyle . self::ENLIGHTERJSCSSPOST);
 
-        return array(
+        return [
             'thejs' => $js,
             'thecss' => $css,
-            'theinit' => "EnlighterJS.init('synhi pre', 'synhi code', {theme: '".$config->enlighterjsstyle."', indent : 4});"
-        );
+            'theinit' => "EnlighterJS.init('synhi pre', 'synhi code', {theme: '" . $config->enlighterjsstyle . "', indent : 4});"
+        ];
     }
 
     /**
@@ -251,11 +252,11 @@ class toolbox {
      */
     private function syntaxhighlighter_init($config) {
         $js = new moodle_url(self::SYNTAXHIGHLIGHTERJS);
-        $css = new moodle_url(self::SYNTAXHIGHLIGHTERCSSPRE.$config->syntaxhighlighterstyle.self::SYNTAXHIGHLIGHTERCSSPOST);
+        $css = new moodle_url(self::SYNTAXHIGHLIGHTERCSSPRE . $config->syntaxhighlighterstyle . self::SYNTAXHIGHLIGHTERCSSPOST);
 
-        return array(
+        return [
             'thejs' => $js,
             'thecss' => $css
-        );
+        ];
     }
 }

--- a/db/services.php
+++ b/db/services.php
@@ -18,7 +18,7 @@
  * SynHi filter.
  *
  * @package    filter_synhi
- * @copyright  &copy; 2020-onwards G J Barnard.
+ * @copyright  © 2020-onwards G J Barnard.
  * @author     G J Barnard - {@link http://moodle.org/user/profile.php?id=442195}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later.
  */

--- a/db/services.php
+++ b/db/services.php
@@ -25,21 +25,21 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$functions = array(
-    'filter_synhi_setting_highlight_example' => array(
+$functions = [
+    'filter_synhi_setting_highlight_example' => [
         'classname' => 'filter_synhi\output\external',
         'methodname' => 'setting_highlight_example',
         'description' => 'Generate the admin setting example highlighted code',
         'type' => 'read',
         'loginrequired' => true,
         'ajax' => true
-    )
-);
+    ]
+];
 
-$services = array(
-    'SynHi Filter admin setting example' => array(
-            'functions' => array('filter_synhi_setting_highlight_example'),
-            'restrictedusers' => 0,
-            'enabled' => 1
-    )
-);
+$services = [
+    'SynHi Filter admin setting example' => [
+        'functions' => ['filter_synhi_setting_highlight_example'],
+        'restrictedusers' => 0,
+        'enabled' => 1
+    ]
+];

--- a/filter.php
+++ b/filter.php
@@ -18,16 +18,18 @@
  * SynHi filter.
  *
  * @package    filter_synhi
- * @copyright  &copy; 2020-onwards G J Barnard.
+ * @copyright  © 2020-onwards G J Barnard.
  * @author     G J Barnard - {@link http://moodle.org/user/profile.php?id=442195}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later.
  */
+
+use filter_synhi\toolbox;
 
 /**
  * SynHi filter.
  *
  * @package    filter_synhi
- * @copyright  &copy; 2020-onwards G J Barnard.
+ * @copyright  © 2020-onwards G J Barnard.
  * @author     G J Barnard - {@link http://moodle.org/user/profile.php?id=442195}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later.
  */
@@ -40,11 +42,12 @@ class filter_synhi extends moodle_text_filter {
 
     /**
      * Filter the text.
+     * Todo: Can't typecast this function because the parent filter does not yet support it :/
      *
      * @param string $text    to be processed by the text
      * @param array  $options filter options
-     *
      * @return string text after processing.
+     * @throws dml_exception
      */
     public function filter($text, array $options = []) {
         // Basic test to avoid work.
@@ -69,7 +72,7 @@ class filter_synhi extends moodle_text_filter {
                                 $text = '<synhi>' . $text . '</synhi>';
                             }
                             if (!self::$done) {
-                                $toolbox = \filter_synhi\toolbox::get_instance();
+                                $toolbox = toolbox::get_instance();
                                 $toolbox->highlight_page($config);
                                 self::$done = true;
                             }

--- a/filter.php
+++ b/filter.php
@@ -41,12 +41,12 @@ class filter_synhi extends moodle_text_filter {
     /**
      * Filter the text.
      *
-     * @param string $text to be processed by the text
-     * @param array $options filter options
+     * @param string $text    to be processed by the text
+     * @param array  $options filter options
      *
      * @return string text after processing.
      */
-    public function filter($text, array $options = array()) {
+    public function filter($text, array $options = []) {
         // Basic test to avoid work.
         if (is_string($text)) {
             if (($this->context->contextlevel >= CONTEXT_COURSE) && ($this->context->contextlevel <= CONTEXT_BLOCK)) {
@@ -66,7 +66,7 @@ class filter_synhi extends moodle_text_filter {
                         $config = get_config('filter_synhi');
                         if (!empty($config->engine)) {
                             if ($config->engine == 'enlighterjs') {
-                                $text = '<synhi>'.$text.'</synhi>';
+                                $text = '<synhi>' . $text . '</synhi>';
                             }
                             if (!self::$done) {
                                 $toolbox = \filter_synhi\toolbox::get_instance();

--- a/lang/en/filter_synhi.php
+++ b/lang/en/filter_synhi.php
@@ -18,7 +18,7 @@
  * SynHi filter.
  *
  * @package    filter_synhi
- * @copyright  &copy; 2020-onwards G J Barnard.
+ * @copyright  © 2020-onwards G J Barnard.
  * @author     G J Barnard - {@link http://moodle.org/user/profile.php?id=442195}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later.
  */
@@ -34,6 +34,12 @@ $string['syntaxhighlighter'] = 'SyntaxHighlighter';
 $string['enlighterjsstyle'] = 'EnlighterJS style';
 $string['syntaxhighlighterstyle'] = 'SyntaxHighlighter style';
 $string['styledesc'] = 'Choose the sytle you wish to use.';
+
+$string['enlighterjsselector1'] = 'EnlighterJS selector 1';
+$string['enlighterjsselector1desc'] = 'EnlighterJS selector 1/2.';
+
+$string['enlighterjsselector2'] = 'EnlighterJS selector 2';
+$string['enlighterjsselector2desc'] = 'EnlighterJS selector 2/2.';
 
 $string['codeexample'] = 'Code';
 $string['codeexampledesc'] = 'Code to use in the example.';

--- a/settings.php
+++ b/settings.php
@@ -31,10 +31,10 @@ if ($ADMIN->fulltree) {
     $description = get_string('enginedesc', 'filter_synhi');
     $default = 'enlighterjs';
     $setting = new admin_setting_configselect($name, $title, $description, $default,
-        array(
+        [
             'enlighterjs' => get_string('enlighterjs', 'filter_synhi'),
             'syntaxhighlighter' => get_string('syntaxhighlighter', 'filter_synhi')
-        )
+        ]
     );
     $settings->add($setting);
 
@@ -69,17 +69,17 @@ if ($ADMIN->fulltree) {
     $name = 'filter_synhi/codeexample';
     $title = get_string('codeexample', 'filter_synhi');
     $description = get_string('codeexampledesc', 'filter_synhi');
-    $default = '<pre class="brush: java">'.PHP_EOL;
-    $default .= 'package test;'.PHP_EOL.PHP_EOL;
-    $default .= 'public class Test {'.PHP_EOL;
-    $default .= '    private final String name = "Java program";'.PHP_EOL.PHP_EOL;
-    $default .= '    public static void main (String args[]) {'.PHP_EOL;
-    $default .= '        Test us = new Test();'.PHP_EOL;
-    $default .= '        System.out.println(us.getName());'.PHP_EOL;
-    $default .= '    }'.PHP_EOL.PHP_EOL;
-    $default .= '    public String getName() {'.PHP_EOL;
-    $default .= '        return name;'.PHP_EOL;
-    $default .= '    }'.PHP_EOL;
+    $default = '<pre class="brush: java">' . PHP_EOL;
+    $default .= 'package test;' . PHP_EOL . PHP_EOL;
+    $default .= 'public class Test {' . PHP_EOL;
+    $default .= '    private final String name = "Java program";' . PHP_EOL . PHP_EOL;
+    $default .= '    public static void main (String args[]) {' . PHP_EOL;
+    $default .= '        Test us = new Test();' . PHP_EOL;
+    $default .= '        System.out.println(us.getName());' . PHP_EOL;
+    $default .= '    }' . PHP_EOL . PHP_EOL;
+    $default .= '    public String getName() {' . PHP_EOL;
+    $default .= '        return name;' . PHP_EOL;
+    $default .= '    }' . PHP_EOL;
     $default .= '}</pre>';
     $setting = new \admin_setting_configtextarea($name, $title, $description, $default);
     $settings->add($setting);
@@ -91,13 +91,13 @@ if ($ADMIN->fulltree) {
 
     $settings->add(new admin_setting_description('filter_synhi_general_information',
         'generalinformation',
-        '<p>'.get_string('generalinformation', 'filter_synhi').'</p>'));
+        '<p>' . get_string('generalinformation', 'filter_synhi') . '</p>'));
 
     $settings->add(new admin_setting_description('filter_synhi_enlighter_information',
         'enlighterinformation',
-        '<p>'.get_string('enlighterinformation', 'filter_synhi').'</p>'));
+        '<p>' . get_string('enlighterinformation', 'filter_synhi') . '</p>'));
 
     $settings->add(new admin_setting_description('filter_synhi_syntaxhighlighter_information',
         'syntaxhighlighterinformation',
-        '<p>'.get_string('syntaxhighlighterinformation', 'filter_synhi').'</p>'));
+        '<p>' . get_string('syntaxhighlighterinformation', 'filter_synhi') . '</p>'));
 }

--- a/settings.php
+++ b/settings.php
@@ -18,7 +18,7 @@
  * SynHi filter.
  *
  * @package    filter_synhi
- * @copyright  &copy; 2020-onwards G J Barnard.
+ * @copyright  © 2020-onwards G J Barnard.
  * @author     G J Barnard - {@link http://moodle.org/user/profile.php?id=442195}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later.
  */
@@ -27,31 +27,53 @@ defined('MOODLE_INTERNAL') || die;
 if ($ADMIN->fulltree) {
     // Engine.
     $name = 'filter_synhi/engine';
-    $title = get_string('engine', 'filter_synhi');
-    $description = get_string('enginedesc', 'filter_synhi');
+    $title = new lang_string('engine', 'filter_synhi');
+    $description = new lang_string('enginedesc', 'filter_synhi');
     $default = 'enlighterjs';
     $setting = new admin_setting_configselect($name, $title, $description, $default,
         [
-            'enlighterjs' => get_string('enlighterjs', 'filter_synhi'),
-            'syntaxhighlighter' => get_string('syntaxhighlighter', 'filter_synhi')
+            'enlighterjs' => new lang_string('enlighterjs', 'filter_synhi'),
+            'syntaxhighlighter' => new lang_string('syntaxhighlighter', 'filter_synhi')
         ]
     );
     $settings->add($setting);
 
     // EnlighterJS style.
     $name = 'filter_synhi/enlighterjsstyle';
-    $title = get_string('enlighterjsstyle', 'filter_synhi');
-    $description = get_string('styledesc', 'filter_synhi');
+    $title = new lang_string('enlighterjsstyle', 'filter_synhi');
+    $description = new lang_string('styledesc', 'filter_synhi');
     $default = 'enlighter';
     $setting = new admin_setting_configselect($name, $title, $description, $default,
         \filter_synhi\toolbox::ENLIGHTERJSSTYLES
     );
     $settings->add($setting);
 
+
+    // EnlighterJS selector 1.
+    $name = 'filter_synhi/enlighterjsselector1';
+    $title = new lang_string('enlighterjsselector1', 'filter_synhi');
+    $description = new lang_string('enlighterjsselector1desc', 'filter_synhi');
+    $default = 'synhi pre';
+    $setting = new admin_setting_configselect($name, $title, $description, $default,
+        \filter_synhi\toolbox::ENLIGHTERSELECTORS
+    );
+    $settings->add($setting);
+
+    // EnlighterJS selector 2.
+    $name = 'filter_synhi/enlighterjsselector2';
+    $title = new lang_string('enlighterjsselector2', 'filter_synhi');
+    $description = new lang_string('enlighterjsselector2desc', 'filter_synhi');
+    $default = 'synhi code';
+    $setting = new admin_setting_configselect($name, $title, $description, $default,
+        \filter_synhi\toolbox::ENLIGHTERSELECTORS
+    );
+    $settings->add($setting);
+
+
     // Syntax Highlighter style.
     $name = 'filter_synhi/syntaxhighlighterstyle';
-    $title = get_string('syntaxhighlighterstyle', 'filter_synhi');
-    $description = get_string('styledesc', 'filter_synhi');
+    $title = new lang_string('syntaxhighlighterstyle', 'filter_synhi');
+    $description = new lang_string('styledesc', 'filter_synhi');
     $default = 'default';
     $setting = new admin_setting_configselect($name, $title, $description, $default,
         \filter_synhi\toolbox::SYNTAXHIGHLIGHTERSTYLES
@@ -60,33 +82,21 @@ if ($ADMIN->fulltree) {
 
     // Syntax Highlighter example.
     $name = 'filter_synhi/syntaxhighlighterexample';
-    $title = get_string('syntaxhighlighterexample', 'filter_synhi');
-    $description = get_string('syntaxhighlighterexampledesc', 'filter_synhi');
+    $title = new lang_string('syntaxhighlighterexample', 'filter_synhi');
+    $description = new lang_string('syntaxhighlighterexampledesc', 'filter_synhi');
     $setting = new \filter_synhi\admin_setting_highlight($name, $title, $description);
     $settings->add($setting);
 
     // Code for the example.
     $name = 'filter_synhi/codeexample';
-    $title = get_string('codeexample', 'filter_synhi');
-    $description = get_string('codeexampledesc', 'filter_synhi');
-    $default = '<pre class="brush: java">' . PHP_EOL;
-    $default .= 'package test;' . PHP_EOL . PHP_EOL;
-    $default .= 'public class Test {' . PHP_EOL;
-    $default .= '    private final String name = "Java program";' . PHP_EOL . PHP_EOL;
-    $default .= '    public static void main (String args[]) {' . PHP_EOL;
-    $default .= '        Test us = new Test();' . PHP_EOL;
-    $default .= '        System.out.println(us.getName());' . PHP_EOL;
-    $default .= '    }' . PHP_EOL . PHP_EOL;
-    $default .= '    public String getName() {' . PHP_EOL;
-    $default .= '        return name;' . PHP_EOL;
-    $default .= '    }' . PHP_EOL;
-    $default .= '}</pre>';
-    $setting = new \admin_setting_configtextarea($name, $title, $description, $default);
+    $title = new lang_string('codeexample', 'filter_synhi');
+    $description = new lang_string('codeexampledesc', 'filter_synhi');
+    $setting = new \admin_setting_configtextarea($name, $title, $description, \filter_synhi\toolbox::EXAMPLECODE);
     $settings->add($setting);
 
     // Information.
     $settings->add(new admin_setting_heading('filter_synhi_information_heading',
-        get_string('informationheading', 'filter_synhi'),
+        new lang_string('informationheading', 'filter_synhi'),
         format_text(get_string('informationheadingdesc', 'filter_synhi'), FORMAT_PLAIN)));
 
     $settings->add(new admin_setting_description('filter_synhi_general_information',

--- a/styles.css
+++ b/styles.css
@@ -1,4 +1,4 @@
 /* Syntax highlighter fixes */
 body .syntaxhighlighter {
-    overflow: visible !important; // stylelint-disable-line declaration-no-important
+    overflow: visible !important; /* stylelint-disable-line declaration-no-important */
 }

--- a/templates/setting_highlight.mustache
+++ b/templates/setting_highlight.mustache
@@ -53,49 +53,49 @@
     </div>
 </div>
 {{#js}}
-require(['jquery', 'core/ajax', 'core/notification', 'core/log'],
+    require(['jquery', 'core/ajax', 'core/notification', 'core/log'],
     function($, Ajax, Notification, log) {
 
     var updateExample = function(engine, style) {
-        Ajax.call([{
-            methodname: 'filter_synhi_setting_highlight_example',
-            args: {
-                'engine': engine,
-                'style': style
-            },
-        }])[0].done(function(response) {
-            log.debug(response.markup);
-            // We have the data now update the UI.
-            $('#setting_highlight_example_frame').replaceWith(response.markup);
-        }).fail(function() {
-                Notification.exception(new Error('Failed to get highlighted markup'));
-                return;
-        });
+    Ajax.call([{
+    methodname: 'filter_synhi_setting_highlight_example',
+    args: {
+    'engine': engine,
+    'style': style
+    },
+    }])[0].done(function(response) {
+    log.debug(response.markup);
+    // We have the data now update the UI.
+    $('#setting_highlight_example_frame').replaceWith(response.markup);
+    }).fail(function() {
+    Notification.exception(new Error('Failed to get highlighted markup'));
+    return;
+    });
     };
 
     log.debug($("#id_s_filter_synhi_engine").val());
     $('#id_s_filter_synhi_engine').change(function() {
-        log.debug( this.value );
+    log.debug( this.value );
 
-        if (this.value == 'enlighterjs') {
-            updateExample(this.value, $("#id_s_filter_synhi_enlighterjsstyle").val());
-        } else if (this.value == 'syntaxhighlighter') {
-            updateExample(this.value, $("#id_s_filter_synhi_syntaxhighlighterstyle").val());
-        }
+    if (this.value == 'enlighterjs') {
+    updateExample(this.value, $("#id_s_filter_synhi_enlighterjsstyle").val());
+    } else if (this.value == 'syntaxhighlighter') {
+    updateExample(this.value, $("#id_s_filter_synhi_syntaxhighlighterstyle").val());
+    }
     });
 
     $('#id_s_filter_synhi_enlighterjsstyle').change(function() {
-        var engine = $("#id_s_filter_synhi_engine").val();
-        if (engine == 'enlighterjs') {
-            updateExample(engine, this.value);
-        }
+    var engine = $("#id_s_filter_synhi_engine").val();
+    if (engine == 'enlighterjs') {
+    updateExample(engine, this.value);
+    }
     });
 
     $('#id_s_filter_synhi_syntaxhighlighterstyle').change(function() {
-        var engine = $("#id_s_filter_synhi_engine").val();
-        if (engine == 'syntaxhighlighter') {
-            updateExample(engine, this.value);
-        }
+    var engine = $("#id_s_filter_synhi_engine").val();
+    if (engine == 'syntaxhighlighter') {
+    updateExample(engine, this.value);
+    }
     });
-});
+    });
 {{/js}}

--- a/templates/setting_highlight_example.mustache
+++ b/templates/setting_highlight_example.mustache
@@ -39,10 +39,10 @@
         <head>
             <title>Example</title>
             {{#highlightdata}}
-                {{#thecss}}
+    {{#thecss}}
                     <link rel='stylesheet' type='text/css' href='{{{thecss}}}'>
                 {{/thecss}}
-            {{/highlightdata}}
+{{/highlightdata}}
             <style>
                 body .syntaxhighlighter {
                     overflow: visible !important;
@@ -53,13 +53,13 @@
             <synhi>{{{code}}}</synhi>
         </body>
         {{#highlightdata}}
-            {{#thejs}}
+    {{#thejs}}
                 <script type='text/javascript' charset='utf-8' src='{{{thejs}}}'></script>
             {{/thejs}}
-            {{#theinit}}
+    {{#theinit}}
                 <script type='text/javascript' charset='utf-8'>{{{theinit}}}</script>
             {{/theinit}}
-        {{/highlightdata}}
+{{/highlightdata}}
     </html>
 " onload="resize_setting_highlight_example_frame(this)"></iframe>
 <script>

--- a/tests/filter_synhi_privacy_provider_test.php
+++ b/tests/filter_synhi_privacy_provider_test.php
@@ -18,7 +18,7 @@
  * SynHi filter.
  *
  * @package    filter_synhi
- * @copyright  &copy; 2020-onwards G J Barnard.
+ * @copyright  © 2020-onwards G J Barnard.
  * @author     G J Barnard - {@link http://moodle.org/user/profile.php?id=442195}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later.
  */
@@ -31,7 +31,7 @@ use filter_synhi\privacy\provider;
  * Privacy unit tests for the SynHi filter.
  *
  * @group      filter_synhi
- * @copyright  &copy; 2020-onwards G J Barnard.
+ * @copyright  © 2020-onwards G J Barnard.
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later.
  */
 class filter_synhi_privacy_provider_test extends \core_privacy\tests\provider_testcase {

--- a/tests/filter_synhi_privacy_provider_test.php
+++ b/tests/filter_synhi_privacy_provider_test.php
@@ -23,12 +23,14 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later.
  */
 
-use \filter_synhi\privacy\provider;
+namespace filter_synhi;
+
+use filter_synhi\privacy\provider;
 
 /**
  * Privacy unit tests for the SynHi filter.
  *
- * @group filter_synhi
+ * @group      filter_synhi
  * @copyright  &copy; 2020-onwards G J Barnard.
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later.
  */
@@ -43,6 +45,7 @@ class filter_synhi_privacy_provider_test extends \core_privacy\tests\provider_te
 
     /**
      * Ensure that get_reason gives a reason.
+     * @covers \provider::get_reason
      */
     public function test_get_reason() {
         $this->set_up();

--- a/tests/filter_synhi_toolbox_test.php
+++ b/tests/filter_synhi_toolbox_test.php
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+namespace filter_synhi;
 /**
  * SynHi filter.
  *
@@ -26,11 +27,11 @@
 /**
  * Toolbox unit tests for the SynHi filter.
  *
- * @group filter_synhi
+ * @group      filter_synhi
  * @copyright  &copy; 2020-onwards G J Barnard.
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later.
  */
-class filter_synhi_toolbox_test extends advanced_testcase {
+class filter_synhi_toolbox_test extends \advanced_testcase {
 
     /**
      * @var string EnlighterJS JS file.
@@ -72,10 +73,10 @@ class filter_synhi_toolbox_test extends advanced_testcase {
     /**
      * Call protected and private methods for the purpose of testing.
      *
-     * @param stdClass $obj The object.
-     * @param string $name Name of the method.
-     * @param array $args Array of arguments if any, like Monty Python could be no minutes, ten, or even thirty.
-     * @return any What the method returns if anything, go, go on, look at the specification, you know you want to.
+     * @param \stdClass $obj  The object.
+     * @param string    $name Name of the method.
+     * @param array     $args Array of arguments if any, like Monty Python could be no minutes, ten, or even thirty.
+     * @return mixed What the method returns if anything, go, go on, look at the specification, you know you want to.
      */
     protected static function call_method($obj, $name, array $args) {
         // Ref: http://stackoverflow.com/questions/249664/best-practices-to-test-protected-methods-with-phpunit.
@@ -96,6 +97,8 @@ class filter_synhi_toolbox_test extends advanced_testcase {
 
     /**
      * Test the setting highlight.
+     *
+     * @covers  \filter_synhi\toolbox::setting_highlight
      */
     public function test_setting_highlight() {
         $this->set_up();
@@ -105,9 +108,9 @@ class filter_synhi_toolbox_test extends advanced_testcase {
 
         $thereturneddata = $this->instance->setting_highlight();
 
-        $csstarget = self::ENLIGHTERJSCSSPRE.'default'.self::ENLIGHTERJSCSSPOST;
-        $thecssurl = new moodle_url($csstarget);
-        $thejsurl = new moodle_url(self::ENLIGHTERJSJS);
+        $csstarget = self::ENLIGHTERJSCSSPRE . 'default' . self::ENLIGHTERJSCSSPOST;
+        $thecssurl = new \moodle_url($csstarget);
+        $thejsurl = new \moodle_url(self::ENLIGHTERJSJS);
         $thecode = "&lt;pre&gt;echo 'This is a test not a drill';&lt;/pre&gt;";
 
         $this->assertEquals($thecssurl, $thereturneddata['highlightdata']['thecss']);
@@ -117,29 +120,32 @@ class filter_synhi_toolbox_test extends advanced_testcase {
 
     /**
      * Test the setting highlight.
+     *
+     * @covers  \filter_synhi\toolbox::setting_highlight_example
      */
     public function test_setting_highlight_example() {
         global $CFG;
+        $phpudata = $CFG->dirroot . '/filter/synhi/tests/phpu_data';
 
         $this->set_up();
         $engine = 'enlighterjs';
         $style = 'godzilla';
 
         $thereturneddata = $this->instance->setting_highlight_example($engine, $style);
-        $theexpectedoutput = file_get_contents($CFG->dirroot.'/filter/synhi/tests/phpu_data/test_setting_highlight_example_enlighterjs_top.txt');
-        $theexpectedoutput .= '            <synhi>&lt;pre class=&quot;brush: java&quot;&gt;'.PHP_EOL;
-        $theexpectedoutput .= 'package test;'.PHP_EOL.PHP_EOL;
-        $theexpectedoutput .= 'public class Test {'.PHP_EOL;
-        $theexpectedoutput .= '    private final String name = &quot;Java program&quot;;'.PHP_EOL.PHP_EOL;
-        $theexpectedoutput .= '    public static void main (String args[]) {'.PHP_EOL;
-        $theexpectedoutput .= '        Test us = new Test();'.PHP_EOL;
-        $theexpectedoutput .= '        System.out.println(us.getName());'.PHP_EOL;
-        $theexpectedoutput .= '    }'.PHP_EOL.PHP_EOL;
-        $theexpectedoutput .= '    public String getName() {'.PHP_EOL;
-        $theexpectedoutput .= '        return name;'.PHP_EOL;
-        $theexpectedoutput .= '    }'.PHP_EOL;
+        $theexpectedoutput = file_get_contents($phpudata . '/test_setting_highlight_example_enlighterjs_top.txt');
+        $theexpectedoutput .= '            <synhi>&lt;pre class=&quot;brush: java&quot;&gt;' . PHP_EOL;
+        $theexpectedoutput .= 'package test;' . PHP_EOL . PHP_EOL;
+        $theexpectedoutput .= 'public class Test {' . PHP_EOL;
+        $theexpectedoutput .= '    private final String name = &quot;Java program&quot;;' . PHP_EOL . PHP_EOL;
+        $theexpectedoutput .= '    public static void main (String args[]) {' . PHP_EOL;
+        $theexpectedoutput .= '        Test us = new Test();' . PHP_EOL;
+        $theexpectedoutput .= '        System.out.println(us.getName());' . PHP_EOL;
+        $theexpectedoutput .= '    }' . PHP_EOL . PHP_EOL;
+        $theexpectedoutput .= '    public String getName() {' . PHP_EOL;
+        $theexpectedoutput .= '        return name;' . PHP_EOL;
+        $theexpectedoutput .= '    }' . PHP_EOL;
         $theexpectedoutput .= '}&lt;/pre&gt;</synhi>';
-        $theexpectedoutput .= file_get_contents($CFG->dirroot.'/filter/synhi/tests/phpu_data/test_setting_highlight_example_enlighterjs_bottom.txt');
+        $theexpectedoutput .= file_get_contents($phpudata . '/test_setting_highlight_example_enlighterjs_bottom.txt');
         $this->assertEquals($theexpectedoutput, $thereturneddata);
 
         $engine = 'valenta';
@@ -153,23 +159,26 @@ class filter_synhi_toolbox_test extends advanced_testcase {
         $style = 'fadetogrey';
         set_config('codeexample', '<pre class="brush: php">echo \'This is a test not a drill\';</pre>', 'filter_synhi');
         $thereturneddata = $this->instance->setting_highlight_example($engine, $style);
-        $theexpectedoutput = file_get_contents($CFG->dirroot.'/filter/synhi/tests/phpu_data/test_setting_highlight_example_enlighterjs.txt');
+        $theexpectedoutput = file_get_contents($phpudata . '/test_setting_highlight_example_enlighterjs.txt');
         $this->assertEquals($theexpectedoutput, $thereturneddata);
     }
 
     /**
      * Test the enlighterjs init.
+     *
+     * @covers  \filter_synhi\toolbox::enlighterjs_init
      */
     public function test_enlighterjs_init() {
         $this->set_up();
-        $thedata = new stdClass;
+        $thedata = new \stdClass;
         $thedata->enlighterjsstyle = 'default';
-        $thereturneddata = self::call_method($this->instance, 'enlighterjs_init',
-            array($thedata));
+        $thereturneddata = self::call_method($this->instance,
+            'enlighterjs_init',
+            [$thedata]);
 
-        $csstarget = self::ENLIGHTERJSCSSPRE.$thedata->enlighterjsstyle.self::ENLIGHTERJSCSSPOST;
-        $thecssurl = new moodle_url($csstarget);
-        $thejsurl = new moodle_url(self::ENLIGHTERJSJS);
+        $csstarget = self::ENLIGHTERJSCSSPRE . $thedata->enlighterjsstyle . self::ENLIGHTERJSCSSPOST;
+        $thecssurl = new \moodle_url($csstarget);
+        $thejsurl = new \moodle_url(self::ENLIGHTERJSJS);
 
         $this->assertEquals($thecssurl, $thereturneddata['thecss']);
         $this->assertEquals($thejsurl, $thereturneddata['thejs']);
@@ -177,17 +186,20 @@ class filter_synhi_toolbox_test extends advanced_testcase {
 
     /**
      * Test the syntaxhighlighter init.
+     *
+     * @covers  \filter_synhi\toolbox::syntaxhighlighter_init
      */
     public function test_syntaxhighlighter_init() {
         $this->set_up();
-        $thedata = new stdClass;
+        $thedata = new \stdClass;
         $thedata->syntaxhighlighterstyle = 'default';
-        $thereturneddata = self::call_method($this->instance, 'syntaxhighlighter_init',
-            array($thedata));
+        $thereturneddata = self::call_method($this->instance,
+            'syntaxhighlighter_init',
+            [$thedata]);
 
-        $csstarget = self::SYNTAXHIGHLIGHTERCSSPRE.$thedata->syntaxhighlighterstyle.self::SYNTAXHIGHLIGHTERCSSPOST;
-        $thecssurl = new moodle_url($csstarget);
-        $thejsurl = new moodle_url(self::SYNTAXHIGHLIGHTERJS);
+        $csstarget = self::SYNTAXHIGHLIGHTERCSSPRE . $thedata->syntaxhighlighterstyle . self::SYNTAXHIGHLIGHTERCSSPOST;
+        $thecssurl = new \moodle_url($csstarget);
+        $thejsurl = new \moodle_url(self::SYNTAXHIGHLIGHTERJS);
 
         $this->assertEquals($thecssurl, $thereturneddata['thecss']);
         $this->assertEquals($thejsurl, $thereturneddata['thejs']);

--- a/tests/filter_synhi_toolbox_test.php
+++ b/tests/filter_synhi_toolbox_test.php
@@ -19,7 +19,7 @@ namespace filter_synhi;
  * SynHi filter.
  *
  * @package    filter_synhi
- * @copyright  &copy; 2020-onwards G J Barnard.
+ * @copyright  © 2020-onwards G J Barnard.
  * @author     G J Barnard - {@link http://moodle.org/user/profile.php?id=442195}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later.
  */
@@ -28,7 +28,7 @@ namespace filter_synhi;
  * Toolbox unit tests for the SynHi filter.
  *
  * @group      filter_synhi
- * @copyright  &copy; 2020-onwards G J Barnard.
+ * @copyright  © 2020-onwards G J Barnard.
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later.
  */
 class filter_synhi_toolbox_test extends \advanced_testcase {

--- a/tests/phpu_data/test_setting_highlight_example_enlighterjs.txt
+++ b/tests/phpu_data/test_setting_highlight_example_enlighterjs.txt
@@ -2,7 +2,8 @@
     <html>
         <head>
             <title>Example</title>
-                    <link rel='stylesheet' type='text/css' href='https://www.example.com/moodle/filter/synhi/javascript/syntaxhighlighter_4_0_1/styles/fadetogrey.css'>
+            <link rel='stylesheet' type='text/css'
+            href='https://www.example.com/moodle/filter/synhi/javascript/syntaxhighlighter_4_0_1/styles/fadetogrey.css'>
             <style>
                 body .syntaxhighlighter {
                     overflow: visible !important;
@@ -12,7 +13,9 @@
         <body>
             <synhi>&lt;pre class=&quot;brush: php&quot;&gt;echo 'This is a test not a drill';&lt;/pre&gt;</synhi>
         </body>
-                <script type='text/javascript' charset='utf-8' src='https://www.example.com/moodle/filter/synhi/javascript/syntaxhighlighter_4_0_1/scripts/syntaxhighlighter.js'></script>
+        <script type='text/javascript' charset='utf-8'
+        src='https://www.example.com/moodle/filter/synhi/javascript/syntaxhighlighter_4_0_1/scripts/syntaxhighlighter.js'>
+        </script>
     </html>
 " onload="resize_setting_highlight_example_frame(this)"></iframe>
 <script>

--- a/tests/phpu_data/test_setting_highlight_example_enlighterjs_bottom.txt
+++ b/tests/phpu_data/test_setting_highlight_example_enlighterjs_bottom.txt
@@ -1,7 +1,10 @@
 
         </body>
-                <script type='text/javascript' charset='utf-8' src='https://www.example.com/moodle/filter/synhi/javascript/EnlighterJS_3_4_0/scripts/enlighterjs.min.js'></script>
-                <script type='text/javascript' charset='utf-8'>EnlighterJS.init('synhi pre', 'synhi code', {theme: 'godzilla', indent : 4});</script>
+        <script type='text/javascript' charset='utf-8'
+        src='https://www.example.com/moodle/filter/synhi/javascript/EnlighterJS_3_4_0/scripts/enlighterjs.min.js'></script>
+        <script type='text/javascript' charset='utf-8'>
+        EnlighterJS.init('synhi pre', 'synhi code', {theme: 'godzilla', indent : 4});
+        </script>
     </html>
 " onload="resize_setting_highlight_example_frame(this)"></iframe>
 <script>

--- a/tests/phpu_data/test_setting_highlight_example_enlighterjs_top.txt
+++ b/tests/phpu_data/test_setting_highlight_example_enlighterjs_top.txt
@@ -2,7 +2,8 @@
     <html>
         <head>
             <title>Example</title>
-                    <link rel='stylesheet' type='text/css' href='https://www.example.com/moodle/filter/synhi/javascript/EnlighterJS_3_4_0/styles/enlighterjs.godzilla.min.css'>
+            <link rel='stylesheet' type='text/css'
+            href='https://www.example.com/moodle/filter/synhi/javascript/EnlighterJS_3_4_0/styles/enlighterjs.godzilla.min.css'>
             <style>
                 body .syntaxhighlighter {
                     overflow: visible !important;

--- a/version.php
+++ b/version.php
@@ -18,14 +18,14 @@
  * SynHi filter.
  *
  * @package    filter_synhi
- * @copyright  &copy; 2020-onwards G J Barnard.
+ * @copyright  © 2020-onwards G J Barnard.
  * @author     G J Barnard - {@link http://moodle.org/user/profile.php?id=442195}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later.
  */
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2020073105;
+$plugin->version = 2023020300;
 $plugin->requires = 2019052000.00; // Moodle Version 3.7 (Build: 20190520).
 $plugin->supported = [37, 400];
 $plugin->component = 'filter_synhi';

--- a/version.php
+++ b/version.php
@@ -25,9 +25,9 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2020073105;
-$plugin->requires  = 2019052000.00; // 3.7 (Build: 20190520).
-$plugin->supported = array(37, 400);
+$plugin->version = 2020073105;
+$plugin->requires = 2019052000.00; // Moodle Version 3.7 (Build: 20190520).
+$plugin->supported = [37, 400];
 $plugin->component = 'filter_synhi';
 $plugin->maturity = MATURITY_STABLE;
 $plugin->release = '3.7.1.2';


### PR DESCRIPTION
This PR contains:
* Codechecker fixes
* php Type declarations which are possible since the 7.4 version of php (where it was possible)
* 2 new Settings enlighterjsselector1 and enlighterjsselector2 which allow the control over which tags should be used.
* fixed up the test cases + coverage.

If there are any question dont mind to ask :)