### PR TITLE
Added enlighterJS enable/disable selector settings

### DIFF
--- a/classes/toolbox.php
+++ b/classes/toolbox.php
@@ -105,6 +105,11 @@ class toolbox {
         'swift' => 'Swift'
     );
 
+    public const ENLIGHTERSELECTORS = array(
+        'synhi pre' => 'synhi pre',
+        'synhi code' => 'synhi code',
+        'none' => 'none'
+    );
 
     /**
      * @var string Default example code.
@@ -234,11 +239,15 @@ class toolbox {
     private function enlighterjs_init($config) {
         $js = new moodle_url(self::ENLIGHTERJSJS);
         $css = new moodle_url(self::ENLIGHTERJSCSSPRE.$config->enlighterjsstyle.self::ENLIGHTERJSCSSPOST);
+        $selector1 = $config->enlighterjsselectorone ?? 'none';
+        $selector1 = $selector1 === 'none' ? 'null' : "'$selector1'";
+        $selector2 = $config->enlighterjsselectortwo ?? 'none';
+        $selector2 = $selector2 === 'none' ? 'null' : "'$selector2'";
 
         return array(
             'thejs' => $js,
             'thecss' => $css,
-            'theinit' => "EnlighterJS.init('synhi pre', 'synhi code', {theme: '".$config->enlighterjsstyle."', indent : 4});"
+            'theinit' => "EnlighterJS.init($selector1, $selector2, {theme: '".$config->enlighterjsstyle."', indent : 4});"
         );
     }
 

--- a/lang/en/filter_synhi.php
+++ b/lang/en/filter_synhi.php
@@ -35,6 +35,11 @@ $string['enlighterjsstyle'] = 'EnlighterJS style';
 $string['syntaxhighlighterstyle'] = 'SyntaxHighlighter style';
 $string['styledesc'] = 'Choose the sytle you wish to use.';
 
+$string['enlighterjsselectorone'] = 'EnlighterJS selector one';
+$string['enlighterjsselectoronedesc'] = 'This is the first of two variables set for enlighterjs. This determines which html tags are used for displaying/formatting code.';
+$string['enlighterjsselectortwo'] = 'EnlighterJS selector two';
+$string['enlighterjsselectortwodesc'] = 'This is the second of two variables set for enlighterjs. This determines which html tags are used for displaying/formatting code.';
+
 $string['codeexample'] = 'Code';
 $string['codeexampledesc'] = 'Code to use in the example.';
 

--- a/settings.php
+++ b/settings.php
@@ -58,6 +58,25 @@ if ($ADMIN->fulltree) {
     );
     $settings->add($setting);
 
+    // EnlighterJS selector one.
+    $name = 'filter_synhi/enlighterjsselectorone';
+    $title = new lang_string('enlighterjsselectorone', 'filter_synhi');
+    $description = new lang_string('enlighterjsselectoronedesc', 'filter_synhi');
+    $default = 'synhi pre';
+    $setting = new admin_setting_configselect($name, $title, $description, $default,
+        \filter_synhi\toolbox::ENLIGHTERSELECTORS
+    );
+    $settings->add($setting);
+    // EnlighterJS selector two.
+    $name = 'filter_synhi/enlighterjsselectortwo';
+    $title = new lang_string('enlighterjsselectortwo', 'filter_synhi');
+    $description = new lang_string('enlighterjsselectortwodesc', 'filter_synhi');
+    $default = 'synhi code';
+    $setting = new admin_setting_configselect($name, $title, $description, $default,
+        \filter_synhi\toolbox::ENLIGHTERSELECTORS
+    );
+    $settings->add($setting);
+
     // Syntax Highlighter example.
     $name = 'filter_synhi/syntaxhighlighterexample';
     $title = get_string('syntaxhighlighterexample', 'filter_synhi');


### PR DESCRIPTION
Hi,
I have evaluated your points from my closed PR and applied them to this PR. If I have attacked you in any way, I am very sorry that was not my intention.

This PR deals with the following feature:
Added two new settings to change the selectors that are passed to enlighterjs. There are still the two selectors already defined by you:
`synhi code` `synhi pre` plus another selector `none` which can be used to disable one of the selectors. 

![grafik](https://user-images.githubusercontent.com/22986332/216939415-395b51f4-79c1-4d2c-88f6-01e7f31301be.png)
